### PR TITLE
Fix single quote escaping

### DIFF
--- a/imessage-wrapped.sh
+++ b/imessage-wrapped.sh
@@ -602,7 +602,7 @@ fi
 SWEET_MESSAGES=$(sqlite3 "$IMESSAGE_DB" "
     SELECT
         m.is_from_me,
-        REPLACE(REPLACE(m.text, '\"', ''), \"'\", '')
+        REPLACE(REPLACE(m.text, '\"', ''), '''', '')
     $BASE_FROM
     WHERE $WHERE_CLAUSE
       AND m.text IS NOT NULL
@@ -615,7 +615,7 @@ SWEET_MESSAGES=$(sqlite3 "$IMESSAGE_DB" "
 RANDOM_MESSAGES=$(sqlite3 "$IMESSAGE_DB" "
     SELECT
         m.is_from_me,
-        REPLACE(REPLACE(m.text, '\"', ''), \"'\", '')
+        REPLACE(REPLACE(m.text, '\"', ''), '''', '')
     $BASE_FROM
     WHERE $WHERE_CLAUSE
       AND m.text IS NOT NULL


### PR DESCRIPTION
I wasn't able to get the script to work on my machine out-of-the-box. I disabled the error silencing, then saw that sqlite was complaining about escaping single quotes.

Using four consecutive single quotes represents one literal single quote in SQL. This is the correct way to escape single quotes within a double-quoted bash string.

After this change, I was able to run the program without any issues. I'm not sure why it was fine on your machine but not on mine. My sqlite3 version is 3.46.0. 